### PR TITLE
fix bug with binding shortcut

### DIFF
--- a/src/divideFragments.ts
+++ b/src/divideFragments.ts
@@ -95,7 +95,11 @@ export function svelteJsParser(fragment: SvelteCodeFragment, fileName?: string):
     }
   } catch (e: any) {
     const errors = e.toString().split('\n');
-    throw new Error(`${errors[0]}${fileName ? ` in file ${fileName}` : ''}\n${errors[1]}`);
+    if (errors.length > 1) {
+      throw new Error(`${errors[0]}${fileName ? ` in file ${fileName}` : ''}\n${errors[1]}`);
+    } else {
+      throw e;
+    }
   }
   return undefined;
 }

--- a/src/divideFragments.ts
+++ b/src/divideFragments.ts
@@ -130,7 +130,25 @@ function getChildFragment(child: TemplateNode, svelteFile: string): SvelteCodeFr
   if (child.type === 'Attribute') {
     return child.value.flatMap((node: TemplateNode) => getChildFragment(node, svelteFile));
   }
-  if (['Binding', 'EventHandler', 'Class', 'Action', 'Transition', 'Animation', 'Let'].includes(child.type)) {
+  if (['Binding'].includes(child.type)) {
+    if (child.expression.type === 'Literal') {
+      /* Example:
+       * <input bind:value="value" /> */
+      return [
+        {
+          fragment: svelteFile.slice(child.expression.start, child.expression.end),
+          startLine: child.expression.loc.start.line,
+          startChar: child.expression.start,
+          endChar: child.expression.end,
+        },
+      ];
+    } else if (child.expression.type === 'Identifier') {
+      /* Example:
+       * <input bind:value /> */
+      // We don't return "Identifiers". Nothing to do here!
+    }
+  }
+  if (['EventHandler', 'Class', 'Action', 'Transition', 'Animation', 'Let'].includes(child.type)) {
     return [
       {
         fragment: svelteFile.slice(child.expression.start, child.expression.end),

--- a/tests/testDivideFragments.test.ts
+++ b/tests/testDivideFragments.test.ts
@@ -756,6 +756,21 @@ describe('Testing parsing of JavaScript in Svelte with HTML', () => {
       ],
     });
   });
+  test('Element with shortcut attribute', () => {
+    const svelteFile = i`
+      <Compontent {attribute} />
+    `;
+    expect(svelteFragmentDivider(svelteFile)).toEqual({
+      htmlFragments: [
+        {
+          fragment: `<Compontent {attribute} />`,
+          startLine: 1,
+          startChar: 0,
+          endChar: 26,
+        },
+      ],
+    });
+  });
   test('Binding', () => {
     const svelteFile = i`
       <Compontent bind:property={'Foo'}>{'Bar'}</Compontent>
@@ -794,6 +809,21 @@ describe('Testing parsing of JavaScript in Svelte with HTML', () => {
           startLine: 2,
           startChar: 93,
           endChar: 98,
+        },
+      ],
+    });
+  });
+  test('Binding shortcut (#1)', () => {
+    const svelteFile = i`
+      <Compontent bind:value></Compontent>
+    `;
+    expect(svelteFragmentDivider(svelteFile)).toEqual({
+      htmlFragments: [
+        {
+          endChar: 36,
+          fragment: `<Compontent bind:value></Compontent>`,
+          startChar: 0,
+          startLine: 1,
         },
       ],
     });

--- a/tests/testDivideFragments.test.ts
+++ b/tests/testDivideFragments.test.ts
@@ -840,48 +840,6 @@ describe('Testing parsing of JavaScript in Svelte with HTML', () => {
       ],
     });
   });
-  test('Binding', () => {
-    const svelteFile = i`
-      <Compontent bind:property={'Foo'}>{'Bar'}</Compontent>
-      <Compontent bind:property={'Baz'}><p>{'Bax'}<p></Compontent>
-    `;
-    expect(svelteFragmentDivider(svelteFile)).toEqual({
-      htmlFragments: [
-        {
-          fragment: `<Compontent bind:property={'Foo'}>{'Bar'}</Compontent>\n<Compontent bind:property={'Baz'}><p>{'Bax'}<p></Compontent>`,
-          startLine: 1,
-          startChar: 0,
-          endChar: 115,
-        },
-      ],
-      scriptInHTMLFragments: [
-        {
-          fragment: "'Foo'",
-          startLine: 1,
-          startChar: 27,
-          endChar: 32,
-        },
-        {
-          fragment: "'Bar'",
-          startLine: 1,
-          startChar: 35,
-          endChar: 40,
-        },
-        {
-          fragment: "'Baz'",
-          startLine: 2,
-          startChar: 82,
-          endChar: 87,
-        },
-        {
-          fragment: "'Bax'",
-          startLine: 2,
-          startChar: 93,
-          endChar: 98,
-        },
-      ],
-    });
-  });
   test('Class', () => {
     const svelteFile = i`
       <Compontent class={'Foo'}>{'Bar'}</Compontent>


### PR DESCRIPTION
- fix parsing of Bindings (fixes #1)
- add test for binding-shortcut (see #1)
- remove duplicated "Binding"
- add test for attribute shortcut
- improve error message for (some) types of errors:

Old error message:
```bash
TypeError: Cannot read properties of undefined (reading 'start')
undefined

       95 |     }
       96 |   } catch (e: any) {
    >  97 |     const errors = e.toString().split('\n');
          |               ^
       98 |     throw new Error(`${errors[0]}${fileName ? ` in file ${fileName}` : ''}\n${errors[1]}`);
       99 |   }
      100 |   return undefined;

      at svelteJsParser (src/divideFragments.ts:97:15)
      at src/divideFragments.ts:78:98
          at Array.flatMap (<anonymous>)
      at svelteFragmentDivider (src/divideFragments.ts:78:76)
      at Object.<anonymous> (tests/testDivideFragments.test.ts:820:48)
```
New error message:
```bash
TypeError: Cannot read properties of undefined (reading 'start')

      135 |       {
      136 |         fragment: svelteFile.slice(child.expression.start, child.expression.end),
    > 137 |         startLine: child.expression.loc.start.line,
          |                                                 ^
      138 |         startChar: child.expression.start,
      139 |         endChar: child.expression.end,
      140 |       },

      at getChildFragment (src/divideFragments.ts:137:49)
      at src/divideFragments.ts:121:30
          at Array.forEach (<anonymous>)
      at getChildFragment (src/divideFragments.ts:120:26)
      at src/divideFragments.ts:87:57
          at Array.flatMap (<anonymous>)
      at svelteJsParser (src/divideFragments.ts:87:38)
      at src/divideFragments.ts:78:98
          at Array.flatMap (<anonymous>)
      at svelteFragmentDivider (src/divideFragments.ts:78:76)
```
