### PR TITLE
fix: support for shortcut boolean attributes

### DIFF
--- a/src/divideFragments.ts
+++ b/src/divideFragments.ts
@@ -128,7 +128,12 @@ function getChildFragment(child: TemplateNode, svelteFile: string): SvelteCodeFr
     return children;
   }
   if (child.type === 'Attribute') {
-    return child.value.flatMap((node: TemplateNode) => getChildFragment(node, svelteFile));
+    /* If the value is not a array nothing is to do.
+     * This is the case for example for shortcut boolean attributes
+     * e.g. 'disabled' in <input disabled> */
+    if (Array.isArray(child.value)) {
+      return child.value.flatMap((node: TemplateNode) => getChildFragment(node, svelteFile));
+    }
   }
   if (['Binding'].includes(child.type)) {
     if (child.expression.type === 'Literal') {

--- a/tests/testDivideFragments.test.ts
+++ b/tests/testDivideFragments.test.ts
@@ -828,6 +828,21 @@ describe('Testing parsing of JavaScript in Svelte with HTML', () => {
       ],
     });
   });
+  test('Binding boolean shortcut', () => {
+    const svelteFile = i`
+      <input type="checkbox" disabled checked />
+    `;
+    expect(svelteFragmentDivider(svelteFile)).toEqual({
+      htmlFragments: [
+        {
+          endChar: 42,
+          fragment: `<input type="checkbox" disabled checked />`,
+          startChar: 0,
+          startLine: 1,
+        },
+      ],
+    });
+  });
   test('EventHandler', () => {
     const svelteFile = i`
       <Compontent on:event={'Foo'}>{'Bar'}</Compontent>


### PR DESCRIPTION
This fixes a bug in handling boolean shortcut attributes like e.g. `disabled` like e.g. here: `<input disabled>`