### PR TITLE
fix: support for shortcut class binding

### DIFF
--- a/src/divideFragments.ts
+++ b/src/divideFragments.ts
@@ -149,14 +149,16 @@ function getChildFragment(child: TemplateNode, svelteFile: string): SvelteCodeFr
     }
   }
   if (['EventHandler', 'Class', 'Action', 'Transition', 'Animation', 'Let'].includes(child.type)) {
-    return [
-      {
-        fragment: svelteFile.slice(child.expression.start, child.expression.end),
-        startLine: child.expression.loc.start.line,
-        startChar: child.expression.start,
-        endChar: child.expression.end,
-      },
-    ];
+    if (child.expression.type === 'Literal') {
+      return [
+        {
+          fragment: svelteFile.slice(child.expression.start, child.expression.end),
+          startLine: child.expression.loc.start.line,
+          startChar: child.expression.start,
+          endChar: child.expression.end,
+        },
+      ];
+    }
   }
   if (['EachBlock', 'IfBlock', 'KeyBlock'].includes(child.type)) {
     return [

--- a/tests/testDivideFragments.test.ts
+++ b/tests/testDivideFragments.test.ts
@@ -885,7 +885,7 @@ describe('Testing parsing of JavaScript in Svelte with HTML', () => {
             <Compontent class={'Baz'}><p>{'Bax'}<p></Compontent>
             <Compontent class:active={'Foo2'}>{'Bar2'}</Compontent>
             <Compontent class:active={'Baz2'}><p>{'Bax2'}<p></Compontent>
-            `,
+          `,
           startLine: 1,
           startChar: 0,
           endChar: 217,
@@ -939,6 +939,25 @@ describe('Testing parsing of JavaScript in Svelte with HTML', () => {
           startLine: 4,
           startChar: 194,
           endChar: 200,
+        },
+      ],
+    });
+  });
+  test('Class shortcuts', () => {
+    const svelteFile = i`
+      <Compontent class:active></Compontent>
+      <Compontent class:valid></Compontent>
+    `;
+    expect(svelteFragmentDivider(svelteFile)).toEqual({
+      htmlFragments: [
+        {
+          fragment: i`
+            <Compontent class:active></Compontent>
+            <Compontent class:valid></Compontent>
+          `,
+          startLine: 1,
+          startChar: 0,
+          endChar: 76,
         },
       ],
     });


### PR DESCRIPTION
fix support for shortcut class binding like e.g. `<Compontent class:active></Compontent>`